### PR TITLE
fix: calendar start period

### DIFF
--- a/src/Service/ReleaseSchedule.php
+++ b/src/Service/ReleaseSchedule.php
@@ -79,7 +79,7 @@ SVG;
 
     private function getSchedulePeriod(): DatePeriod
     {
-        $startDate = new DateTime('-3 years');
+        $startDate = new DateTime('2021-01-01');
         $endDate = new DateTime('+2 years');
 
         $startDate->modify('first day of January');


### PR DESCRIPTION
We have to adjust the start date to a fixed date until we can remove the old 6.4 versions. 